### PR TITLE
Footers link fix.

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -78,7 +78,7 @@ export default function Footer() {
                   return (
                     <a href={link.link} target={link.target ? link.target : '_self'} key={index}>
                       <p>{link.title}</p>
-                    </Link>
+                    </a>
                   )
                 })}
               </div>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -75,21 +75,15 @@ export default function Footer() {
                     return <p key={index}>{link.title}</p>
                   }
 
-   return ( 
-     
+ return (           
 	 link.link.startsWith("https://")
 	 	?<a href={link.link} target={link.target ? link.target : '_self'} key={index}>
   				<p>{link.title}</p>
 	 	</a>
-		:<Link to={link.link} target={link.target ? link.target : '_self'} key={index}>		            
-      <p>{link.title}</p> 
+		:<Link to={link.link} target={link.target ? link.target : '_self'} key={index}>
+	 		<p>{link.title}</p> 
 	 	</Link>
-  
-)	
-                })}
-              </div>
-            )
-
+  )	
                 })}
               </div>
             )

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -75,11 +75,21 @@ export default function Footer() {
                     return <p key={index}>{link.title}</p>
                   }
 
-                  return (
-                    <a href={link.link} target={link.target ? link.target : '_self'} key={index}>
-                      <p>{link.title}</p>
-                    </a>
-                  )
+   return ( 
+     
+	 link.link.startsWith("https://")
+	 	?<a href={link.link} target={link.target ? link.target : '_self'} key={index}>
+  				<p>{link.title}</p>
+	 	</a>
+		:<Link to={link.link} target={link.target ? link.target : '_self'} key={index}>		            
+      <p>{link.title}</p> 
+	 	</Link>
+  
+)	
+                })}
+              </div>
+            )
+
                 })}
               </div>
             )

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -76,7 +76,7 @@ export default function Footer() {
                   }
 
                   return (
-                    <Link to={link.link} target={link.target ? link.target : '_self'} key={index}>
+                    <a href={link.link} target={link.target ? link.target : '_self'} key={index}>
                       <p>{link.title}</p>
                     </Link>
                   )


### PR DESCRIPTION
The links in the footer sections were redirecting to the original URL with links as routes.
<Link> replace <a>.
